### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ !github.head_ref }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
       - name: Pack
@@ -35,12 +35,12 @@ jobs:
       OS: linux
       TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
           fetch-depth: 0
       - name: Set up cache
-        uses: actions/cache@v4.1.1
+        uses: actions/cache@v4.1.2
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
@@ -57,13 +57,13 @@ jobs:
       - name: Install GCC PPA
         run: sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
       - name: Install New Packages
-        uses: gerlero/apt-install@v1.2.2
+        uses: gerlero/apt-install@v1.3.9
         with:
           packages: ccache gcc-14 g++-14 clang-19 clang-tools-19 clang-19-doc libclang-common-19-dev libclang-19-dev libclang1-19 clang-format-19 python3-clang-19 clangd-19 clang-tidy-19 autoconf git glslang-tools libva2 libva-dev libasound2t64 libboost-context-dev libglu1-mesa-dev libhidapi-dev libpulse-dev libtool libudev-dev libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0 libxcb-xkb1 libxext-dev libxkbcommon-x11-0 mesa-common-dev nasm libmbedtls-dev catch2 libfmt-dev liblz4-dev nlohmann-json3-dev libssl-dev libavfilter-dev libavcodec-dev libswscale-dev build-essential gstreamer1.0-gl gstreamer1.0-plugins-base libcdparanoia0 libegl-dev libegl-mesa0 libegl1 libgl1-mesa-dev libgles-dev libgles1 libgles2 libglvnd-core-dev libglvnd-dev libgraphene-1.0-0 libgstreamer-gl1.0-0 libgstreamer-plugins-base1.0-0 liborc-0.4-0t64 libvisual-0.4-0 libxcb-cursor0 libxcb-shape0 libxcb-xkb-dev libxkbcommon-dev apparmor cloud-init firefox libapparmor1 libapr1t64 libcups2t64 libopenjp2-7 libproc2-0 linux-azure linux-cloud-tools-azure linux-headers-azure linux-image-azure linux-tools-azure lxd-agent-loader mdadm nvme-cli open-vm-tools procps python3-update-manager systemd-hwe-hwdb ubuntu-pro-client ubuntu-pro-client-l10n update-manager-core php8.3 php8.3-bcmath php8.3-bz2 php8.3-cgi php8.3-cli php8.3-common php8.3-curl php8.3-dba php8.3-dev php8.3-enchant php8.3-fpm php8.3-gd php8.3-gmp php8.3-imap php8.3-interbase php8.3-intl php8.3-ldap php8.3-mbstring php8.3-mysql php8.3-odbc php8.3-opcache php8.3-pgsql php8.3-phpdbg php8.3-pspell php8.3-readline php8.3-snmp php8.3-soap php8.3-sqlite3 php8.3-sybase php8.3-tidy php8.3-xml php8.3-xsl php8.3-zip vim vim-common vim-runtime vim-tiny xxd
       - name: Update System Packages
         run: sudo apt-get update && sudo apt-get -y dist-upgrade && sudo apt-get clean
       - name: Get latest CMake and Ninja
-        uses: lukka/get-cmake@v3.30.5
+        uses: lukka/get-cmake@v3.31.0
         with:
           cmakeVersion: latest
           ninjaVersion: latest
@@ -82,7 +82,7 @@ jobs:
             toolset: gcc
             link: static+shared
       - name: Install Qt
-        uses: jurplel/install-qt-action@v4
+        uses: jurplel/install-qt-action@v4.1.1
         with:
           aqtversion: '==3.1.*'
           version: '6.7.*'
@@ -157,11 +157,11 @@ jobs:
       OS: macos
       TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4.1.1
+        uses: actions/cache@v4.1.2
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
@@ -176,7 +176,7 @@ jobs:
         with:
           tools: ccache ninja automake ccache ffmpeg glslang hidapi ninja nlohmann-json sdl2 speexdsp zlib
       - name: Install Qt
-        uses: jurplel/install-qt-action@v4
+        uses: jurplel/install-qt-action@v4.1.1
         with:
           aqtversion: '==3.1.*'
           version: '6.7.*'
@@ -239,7 +239,7 @@ jobs:
             Boost_INCLUDE_DIR: ${{steps.install-boost.outputs.BOOST_ROOT}}/include
             Boost_LIBRARY_DIRS: ${{steps.install-boost.outputs.BOOST_ROOT}}/lib
       - name: Cache outputs for universal build
-        uses: actions/cache/save@v4.1.1
+        uses: actions/cache/save@v4.1.2
         with:
           path: ${{ env.OS }}-${{ env.TARGET }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -259,11 +259,11 @@ jobs:
       OS: macos
       TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4.1.1
+        uses: actions/cache@v4.1.2
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
@@ -278,7 +278,7 @@ jobs:
         with:
           tools: ccache ninja autoconf automake ccache ffmpeg glslang hidapi libtool nlohmann-json sdl2 speexdsp zlib
       - name: Install Qt
-        uses: jurplel/install-qt-action@v4
+        uses: jurplel/install-qt-action@v4.1.1
         with:
           aqtversion: '==3.1.*'
           version: '6.7.*'
@@ -341,7 +341,7 @@ jobs:
             Boost_INCLUDE_DIR: ${{steps.install-boost.outputs.BOOST_ROOT}}/include
             Boost_LIBRARY_DIRS: ${{steps.install-boost.outputs.BOOST_ROOT}}/lib
       - name: Cache outputs for universal build
-        uses: actions/cache/save@v4.1.1
+        uses: actions/cache/save@v4.1.2
         with:
           path: ${{ env.OS }}-${{ env.TARGET }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -356,15 +356,15 @@ jobs:
       OS: macos
       TARGET: universal
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
       - name: Download x86_64 build from cache
-        uses: actions/cache/restore@v4.1.1
+        uses: actions/cache/restore@v4.1.2
         with:
           path: ${{ env.OS }}-x86_64
           key: ${{ runner.os }}-x86_64-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           fail-on-cache-miss: true
       - name: Download ARM64 build from cache
-        uses: actions/cache/restore@v4.1.1
+        uses: actions/cache/restore@v4.1.2
         with:
           path: ${{ env.OS }}-arm64
           key: ${{ runner.os }}-arm64-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -395,12 +395,12 @@ jobs:
       OS: windows
       TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
           fetch-depth: 0
       - name: Set up cache
-        uses: actions/cache@v4.1.1
+        uses: actions/cache@v4.1.2
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
@@ -419,7 +419,7 @@ jobs:
           cache: true
         if: ${{ matrix.target == 'msvc' }}
       - name: Install Qt
-        uses: jurplel/install-qt-action@v4
+        uses: jurplel/install-qt-action@v4.1.1
         with:
           aqtversion: '==3.1.*'
           version: '6.7.*'
@@ -497,11 +497,11 @@ jobs:
       OS: windows
       TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4.1.1
+        uses: actions/cache@v4.1.2
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
@@ -564,12 +564,12 @@ jobs:
       OS: android
       TARGET: universal
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
           fetch-depth: 0
       - name: Set up cache
-        uses: actions/cache@v4.1.1
+        uses: actions/cache@v4.1.2
         with:
           path: |
             ~/.gradle/caches
@@ -582,12 +582,12 @@ jobs:
         uses: olegtarasov/get-tag@v2.1.3
         id: tagName
       - name: Set up JDK 22
-        uses: actions/setup-java@v4.4.0
+        uses: actions/setup-java@v4.5.0
         with:
           java-version: '22'
           distribution: 'temurin'
       - name: Install New Packages
-        uses: gerlero/apt-install@v1.2.2
+        uses: gerlero/apt-install@v1.3.9
         with:
           packages: ccache apksigner glslang-dev glslang-tools apparmor cloud-init firefox libapparmor1 libapr1t64 libcups2t64 libopenjp2-7 libproc2-0 linux-azure linux-cloud-tools-azure linux-headers-azure linux-image-azure linux-tools-azure lxd-agent-loader mdadm nvme-cli open-vm-tools procps python3-update-manager systemd-hwe-hwdb ubuntu-pro-client ubuntu-pro-client-l10n update-manager-core php8.3 php8.3-bcmath php8.3-bz2 php8.3-cgi php8.3-cli php8.3-common php8.3-curl php8.3-dba php8.3-dev php8.3-enchant php8.3-fpm php8.3-gd php8.3-gmp php8.3-imap php8.3-interbase php8.3-intl php8.3-ldap php8.3-mbstring php8.3-mysql php8.3-odbc php8.3-opcache php8.3-pgsql php8.3-phpdbg php8.3-pspell php8.3-readline php8.3-snmp php8.3-soap php8.3-sqlite3 php8.3-sybase php8.3-tidy php8.3-xml php8.3-xsl php8.3-zip vim vim-common vim-runtime vim-tiny xxd
       - name: Update system packages

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.UPDATEACTIONS }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[gerlero/apt-install](https://github.com/gerlero/apt-install)** published a new release **[v1.3.9](https://github.com/gerlero/apt-install/releases/tag/v1.3.9)** on 2024-10-23T20:48:52Z
* **[lukka/get-cmake](https://github.com/lukka/get-cmake)** published a new release **[v3.31.0](https://github.com/lukka/get-cmake/releases/tag/v3.31.0)** on 2024-11-07T05:37:10Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.1.2](https://github.com/actions/cache/releases/tag/v4.1.2)** on 2024-10-22T13:08:44Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.5.0](https://github.com/actions/setup-java/releases/tag/v4.5.0)** on 2024-10-24T13:59:09Z
* **[jurplel/install-qt-action](https://github.com/jurplel/install-qt-action)** published a new release **[v4.1.1](https://github.com/jurplel/install-qt-action/releases/tag/v4.1.1)** on 2024-11-11T23:52:56Z
